### PR TITLE
invalidate access token cookie on cas redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Invalidate access token cookie on cas redirect ([#8](https://github.com/scm-manager/scm-cas-plugin/pull/8))
+
 ## 2.1.0 - 2020-09-01
 ### Added
 - Integrate full anonymous access mode ([#5](https://github.com/scm-manager/scm-cas-plugin/pull/5))

--- a/src/test/java/com/cloudogu/scm/cas/browser/ForceCasLoginFilterTest.java
+++ b/src/test/java/com/cloudogu/scm/cas/browser/ForceCasLoginFilterTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import sonia.scm.config.ScmConfiguration;
+import sonia.scm.security.AccessTokenCookieIssuer;
 import sonia.scm.security.AnonymousMode;
 import sonia.scm.web.UserAgent;
 import sonia.scm.web.UserAgentParser;
@@ -87,6 +88,9 @@ class ForceCasLoginFilterTest {
   @Mock
   private UserAgentParser userAgentParser;
 
+  @Mock
+  private AccessTokenCookieIssuer accessTokenCookieIssuer;
+
   private ForceCasLoginFilter filter;
 
   private ThreadState subjectThreadState;
@@ -102,7 +106,7 @@ class ForceCasLoginFilterTest {
     when(casContext.get()).thenReturn(configuration);
     when(serviceUrlProvider.create()).thenReturn(SERVICE_URL);
 
-    filter = new ForceCasLoginFilter(serviceUrlProvider, casContext, scmConfiguration, userAgentParser);
+    filter = new ForceCasLoginFilter(serviceUrlProvider, casContext, scmConfiguration, userAgentParser, accessTokenCookieIssuer);
 
     subjectThreadState = new SubjectThreadState(subject);
     subjectThreadState.bind();
@@ -120,6 +124,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(response).sendRedirect(CAS_LOGIN_URL + "?service=" + SERVICE_URL_ESCAPED);
+    verify(accessTokenCookieIssuer).invalidate(request, response);
   }
 
   @Test
@@ -130,6 +135,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -141,6 +147,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(response).sendRedirect(CAS_LOGIN_URL + "?service=" + SERVICE_URL_ESCAPED);
+    verify(accessTokenCookieIssuer).invalidate(request, response);
   }
 
   @Test
@@ -153,6 +160,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -165,6 +173,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -176,6 +185,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -185,6 +195,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -196,6 +207,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain, never()).doFilter(request, response);
+    verify(accessTokenCookieIssuer).invalidate(request, response);
   }
 
   @Test
@@ -210,6 +222,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -222,6 +235,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(chain).doFilter(request, response);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   @Test
@@ -233,6 +247,7 @@ class ForceCasLoginFilterTest {
     filter.doFilter(request, response, chain);
 
     verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(accessTokenCookieIssuer, never()).invalidate(request, response);
   }
 
   private void mockNonBrowserRequest() {


### PR DESCRIPTION
## Proposed changes

The CAS Plugin did not correctly invalidate the cookie, leading to a json error response being displayed in the browser when the access token expired.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [ ] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [ ] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
